### PR TITLE
Add analytics fetcher and Telegram bot

### DIFF
--- a/fetch_turnover_stocks.py
+++ b/fetch_turnover_stocks.py
@@ -1,0 +1,27 @@
+import os
+from datetime import datetime, timedelta
+from vot.fetchers.Analytics import TurnoverStocks
+from vot.tools.json_utils import json_dumps
+
+
+def main() -> None:
+    headers = {
+        "Client-Id": os.getenv("OZON_CLIENT_ID", ""),
+        "Api-Key": os.getenv("OZON_API_KEY", ""),
+    }
+    end = datetime.utcnow()
+    start = end - timedelta(days=7)
+    start_str = start.strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_str = end.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    stocks = TurnoverStocks(headers, start_str, end_str)
+    stocks.run()
+
+    os.makedirs("mock", exist_ok=True)
+    with open(os.path.join("mock", "turnover_stocks.json"), "w", encoding="utf-8") as f:
+        f.write(json_dumps(stocks.data))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/fetchers/Analytics.py
+++ b/fetchers/Analytics.py
@@ -1,0 +1,33 @@
+import requests
+from datetime import datetime, timedelta
+from typing import Dict
+
+from ..tools.json_utils import json_dumps
+from ..tools.exceptions import APIError, APIConnectionError
+
+
+class TurnoverStocks:
+    """Get stock turnover analytics."""
+
+    def __init__(self, headers: Dict, date_since: str, date_to: str) -> None:
+        self.headers = headers
+        self.url = "https://api-seller.ozon.ru/v1/analytics/turnover/stocks"
+        self.date_since = date_since
+        self.date_to = date_to
+        self.data = None
+
+    def _request_body(self) -> str:
+        body = {
+            "date_from": self.date_since,
+            "date_to": self.date_to,
+        }
+        return json_dumps(body)
+
+    def run(self) -> None:
+        try:
+            result = requests.post(self.url, headers=self.headers, data=self._request_body())
+        except ConnectionError:
+            raise APIConnectionError()
+        if result.status_code != 200:
+            raise APIError(result.json().get("message", ""), result.status_code, self.url)
+        self.data = result.json()

--- a/fetchers/FBO.py
+++ b/fetchers/FBO.py
@@ -1,6 +1,6 @@
 import asyncio
 from aiohttp import ClientSession
-import json
+from ..tools.json_utils import json_dumps
 from pandas import to_datetime, offsets, Timestamp
 
 from ..tools.functions import dates_delta, manage_asyncio_wait
@@ -59,7 +59,7 @@ class FBOPostingList:
                          "financial_data": True}}
         # Для отладки.
         print(body["filter"]["since"], " --> ", body["filter"]["to"], body["offset"])
-        body = json.dumps(body)
+        body = json_dumps(body)
         return body
 
     async def _fetch(self, session: ClientSession, since: Timestamp):

--- a/fetchers/FBS.py
+++ b/fetchers/FBS.py
@@ -1,6 +1,6 @@
 import asyncio
 from aiohttp import ClientSession
-import json
+from ..tools.json_utils import json_dumps
 from pandas import to_datetime, offsets, Timestamp
 from ..tools.functions import dates_delta, manage_asyncio_wait
 
@@ -64,7 +64,7 @@ class FBSPostingList:
         }
         # Для отладки.
         print(body["filter"]["since"], " --> ", body["filter"]["to"], body["offset"])
-        body = json.dumps(body)
+        body = json_dumps(body)
         return body
 
     async def _fetch(self, session: ClientSession, since: Timestamp) -> None:

--- a/fetchers/Finance.py
+++ b/fetchers/Finance.py
@@ -1,6 +1,6 @@
 import asyncio
 from aiohttp import ClientSession
-import json
+from ..tools.json_utils import json_dumps
 from pandas import to_datetime, Timestamp
 from dateutil.relativedelta import relativedelta
 from ..tools.functions import manage_asyncio_wait
@@ -63,7 +63,7 @@ class AsyncFinanceRealizationList:
         }
         # Для отладки.
         print(body["filter"]["date"]["from"], " --> ", body["filter"]["date"]["to"], body["page"])
-        body = json.dumps(body)
+        body = json_dumps(body)
         return body
 
     async def _fetch(self, session: ClientSession, date_since: Timestamp, date_to: Timestamp) -> None:

--- a/fetchers/Products.py
+++ b/fetchers/Products.py
@@ -1,5 +1,5 @@
 import requests
-import json
+from ..tools.json_utils import json_dumps
 from typing import Dict, AnyStr, List, Tuple
 from copy import deepcopy
 from ..tools.functions import flatten_dict
@@ -70,7 +70,7 @@ class Products:
         :param api_method: API-метод, который будет использован для создания post-запроса.
         """
         try:
-            req = requests.post(api_method, headers=self.headers, data=json.dumps(self.body))
+            req = requests.post(api_method, headers=self.headers, data=json_dumps(self.body))
         except ConnectionError:
             raise ConnectionError()
 
@@ -127,7 +127,7 @@ class Products:
         thousands = (len(products_id) / 1000).__ceil__()
         for n_thousand in range(thousands):
             body = {"product_id": products_id[(1000 * n_thousand):(1000 * (n_thousand + 1))]}
-            body = json.dumps(body)
+            body = json_dumps(body)
 
             try:
                 req = requests.post(self.urls["product_info_list"], headers=self.headers, data=body)

--- a/fetchers/SellerRating.py
+++ b/fetchers/SellerRating.py
@@ -1,5 +1,5 @@
 import requests
-import json
+from ..tools.json_utils import json_dumps
 from typing import Dict
 
 
@@ -34,7 +34,7 @@ class SellerRating:
         :return: Словарь с информацией о рейтинге магазина.
         """
         try:
-            req = requests.post(self.url, headers=self.headers, data=json.dumps({}))
+            req = requests.post(self.url, headers=self.headers, data=json_dumps({}))
         except ConnectionError:
             raise ConnectionError
         if req.status_code != 200:

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,3 +105,5 @@ webencodings==0.5.1
 websocket-client==1.8.0
 widgetsnbextension==4.0.10
 yarl==1.9.4
+orjson==3.11.0
+python-telegram-bot==20.4

--- a/telegram_pnl_bot.py
+++ b/telegram_pnl_bot.py
@@ -1,0 +1,40 @@
+import os
+from datetime import datetime, timedelta
+import asyncio
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+from vot.fetchers.Finance import AsyncFinanceRealizationList
+
+
+def calculate_pnl(operations) -> float:
+    return sum(float(op.get('amount', 0)) for op in operations)
+
+
+async def pnl_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    headers = {
+        "Client-Id": os.getenv("OZON_CLIENT_ID", ""),
+        "Api-Key": os.getenv("OZON_API_KEY", ""),
+    }
+    end = datetime.utcnow()
+    start = end - timedelta(days=7)
+    start_str = start.strftime("%Y.%m.%d")
+    end_str = end.strftime("%Y.%m.%d")
+
+    finance = AsyncFinanceRealizationList(headers, start_str, end_str)
+    await finance.run_in_jupyter()
+    pnl_value = calculate_pnl(finance.data)
+    await context.bot.send_message(chat_id=update.effective_chat.id,
+                                   text=f"PNL за неделю: {pnl_value}")
+
+
+def main() -> None:
+    bot_token = os.getenv("TELEGRAM_BOT_TOKEN", "")
+    application = ApplicationBuilder().token(bot_token).build()
+    application.add_handler(CommandHandler("pnl", pnl_command))
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/json_utils.py
+++ b/tools/json_utils.py
@@ -1,0 +1,19 @@
+try:
+    import orjson
+except ImportError:  # pragma: no cover - fallback to builtin json
+    orjson = None
+import json
+
+
+def json_dumps(data) -> str:
+    """Serialize Python object to JSON string."""
+    if orjson:
+        return orjson.dumps(data, option=orjson.OPT_NON_STR_KEYS).decode()
+    return json.dumps(data, ensure_ascii=False)
+
+
+def json_loads(data: str):
+    """Deserialize JSON string to Python object."""
+    if orjson:
+        return orjson.loads(data)
+    return json.loads(data)


### PR DESCRIPTION
## Summary
- add JSON utils using orjson if available
- refactor fetchers to use new json helpers
- implement TurnoverStocks fetcher for `/v1/analytics/turnover/stocks`
- script to save last week's turnover stocks data
- telegram bot for weekly PNL report
- include empty `mock` folder
- update requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877c359a13c83309941fbdb7cdce2be