### PR TITLE
Add Docker support with usage docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["python", "telegram_pnl_bot.py"]

--- a/README.md
+++ b/README.md
@@ -51,3 +51,49 @@ ___
     * `test`: Примеры использования пакета.
         * `examples.ipynb`
 
+### Использование
+
+Основной точкой входа является скрипт `telegram_pnl_bot.py`. После запуска бот
+в Telegram будет отвечать на команду `/pnl` и возвращать значение PNL за
+последние 7 дней. Перед запуском необходимо указать переменные окружения:
+
+- `TELEGRAM_BOT_TOKEN` – токен вашего Telegram-бота.
+- `OZON_CLIENT_ID` и `OZON_API_KEY` – данные для доступа к Ozon API.
+
+Для запуска бота напрямую из Python выполните:
+
+```bash
+pip install -r requirements.txt
+python telegram_pnl_bot.py
+```
+
+### Запуск в Docker
+
+В репозитории присутствует `Dockerfile`, позволяющий собрать образ со всеми
+зависимостями. Сборка образа:
+
+```bash
+docker build -t ozon_bot .
+```
+
+Запуск контейнера:
+
+```bash
+docker run -e TELEGRAM_BOT_TOKEN=<token> \
+           -e OZON_CLIENT_ID=<client_id> \
+           -e OZON_API_KEY=<api_key> ozon_bot
+```
+
+Контейнер автоматически запустит Telegram‑бота.
+
+
+### Docker Compose
+
+Для быстрого запуска используйте `docker-compose.yml`. Укажите переменные окружения `TELEGRAM_BOT_TOKEN`, `OZON_CLIENT_ID` и `OZON_API_KEY` и выполните:
+
+```bash
+docker-compose up --build
+```
+
+При желании можно добавить `-d`, чтобы запустить сервис в фоне. Контейнер автоматически запустит Telegram‑бота.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  bot:
+    build: .
+    environment:
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
+      OZON_CLIENT_ID: ${OZON_CLIENT_ID}
+      OZON_API_KEY: ${OZON_API_KEY}
+    restart: unless-stopped
+


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` for easy startup of the Telegram PNL bot
- document how to launch the project with docker-compose

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877c5728ec08330a64371156228c2a5