### PR TITLE
Fix Telegram bot dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -106,4 +106,4 @@ websocket-client==1.8.0
 widgetsnbextension==4.0.10
 yarl==1.9.4
 orjson==3.11.0
-python-telegram-bot==20.4
+python-telegram-bot==21.0


### PR DESCRIPTION
## Summary
- update `python-telegram-bot` package to resolve `httpx` conflicts

## Testing
- `python -m py_compile telegram_pnl_bot.py fetchers/*.py tools/*.py annotations/*.py fetch_turnover_stocks.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6877e4bcd44c83309d223a0217a9ef4b